### PR TITLE
Create entities relating to Song and add audio playing functionality

### DIFF
--- a/src/entity/AudioSource.java
+++ b/src/entity/AudioSource.java
@@ -1,0 +1,8 @@
+package entity;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface AudioSource {
+    InputStream getAudioStream() throws IOException;
+}

--- a/src/entity/FileAudioSource.java
+++ b/src/entity/FileAudioSource.java
@@ -1,0 +1,20 @@
+package entity;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class FileAudioSource implements AudioSource {
+    private final String audioFilePath;
+
+    public FileAudioSource(String audioFilePath) {
+        this.audioFilePath = audioFilePath;
+    }
+
+    @Override
+    public InputStream getAudioStream() throws IOException {
+        FileInputStream fileInputStream = new FileInputStream(this.audioFilePath);
+        return new BufferedInputStream(fileInputStream);
+    }
+}

--- a/src/entity/MP3SongPlayer.java
+++ b/src/entity/MP3SongPlayer.java
@@ -1,0 +1,45 @@
+package entity;
+
+import javazoom.jl.decoder.JavaLayerException;
+import javazoom.jl.player.advanced.AdvancedPlayer;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class MP3SongPlayer implements SongPlayer {
+    private AdvancedPlayer player;
+    private Thread playbackThread;
+
+    @Override
+    public void playAudio(AudioSource mp3AudioSource) {
+        try {
+            InputStream audioInputStream = mp3AudioSource.getAudioStream();
+            this.player = new AdvancedPlayer(audioInputStream);
+            this.playbackThread = new Thread(() -> {
+                try {
+                    this.player.play(msToFrames(10000));
+                } catch (JavaLayerException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            this.playbackThread.start();
+        } catch (IOException | JavaLayerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void stopAudio() {
+        if (this.player != null && playbackThread != null && playbackThread.isAlive()) {
+            System.out.println("in stopAudio");
+            this.player.close();
+            this.playbackThread.interrupt();
+            System.out.println("stopAudio is done");
+        }
+    }
+
+    private int msToFrames(int ms) {
+        int msPerFrame = 26;
+        return ms / msPerFrame;
+    }
+}

--- a/src/entity/MP3SongPlayer.java
+++ b/src/entity/MP3SongPlayer.java
@@ -17,7 +17,7 @@ public class MP3SongPlayer implements SongPlayer {
             this.player = new AdvancedPlayer(audioInputStream);
             this.playbackThread = new Thread(() -> {
                 try {
-                    this.player.play(msToFrames(10000));
+                    this.player.play(msToFrames(10000)); // 10 secs
                 } catch (JavaLayerException e) {
                     throw new RuntimeException(e);
                 }
@@ -31,10 +31,8 @@ public class MP3SongPlayer implements SongPlayer {
     @Override
     public void stopAudio() {
         if (this.player != null && playbackThread != null && playbackThread.isAlive()) {
-            System.out.println("in stopAudio");
             this.player.close();
             this.playbackThread.interrupt();
-            System.out.println("stopAudio is done");
         }
     }
 

--- a/src/entity/Song.java
+++ b/src/entity/Song.java
@@ -1,0 +1,36 @@
+package entity;
+
+/*
+ * Entity representing a playable song.
+ *
+ * Representation invariants:
+ *   - <audioSource> should be compatible with <songPlayer> (e.g. an MP3 audio source should be used with MP3SongPlayer)
+ */
+public class Song {
+    private final String title;
+    private final String artist;
+    private final AudioSource audioSource;
+    private final SongPlayer songPlayer;
+
+    public Song(String title, String artist, AudioSource audioSource, SongPlayer songPlayer) {
+        this.title = title;
+        this.artist = artist;
+        this.audioSource = audioSource;
+        this.songPlayer = songPlayer;
+    }
+
+    public void playAudio() {
+        songPlayer.playAudio(audioSource);
+    }
+
+    public void stopAudio() { this.songPlayer.stopAudio(); }
+
+    @Override
+    public String toString() {
+        return String.format("%s - %s", this.artist, this.title);
+    }
+
+    public String getTitle() { return this.title; }
+
+    public String getArtist() { return this.artist; }
+}

--- a/src/entity/Song.java
+++ b/src/entity/Song.java
@@ -20,10 +20,12 @@ public class Song {
     }
 
     public void playAudio() {
-        songPlayer.playAudio(audioSource);
+        this.songPlayer.playAudio(audioSource);
     }
 
-    public void stopAudio() { this.songPlayer.stopAudio(); }
+    public void stopAudio() {
+        this.songPlayer.stopAudio();
+    }
 
     @Override
     public String toString() {

--- a/src/entity/SongPlayer.java
+++ b/src/entity/SongPlayer.java
@@ -1,0 +1,6 @@
+package entity;
+
+public interface SongPlayer {
+    public void playAudio(AudioSource audioSource);
+    public void stopAudio();
+}

--- a/src/entity/URLAudioSource.java
+++ b/src/entity/URLAudioSource.java
@@ -1,0 +1,22 @@
+package entity;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class URLAudioSource implements AudioSource {
+    private final String audioUrlPath;
+
+    public URLAudioSource(String audioUrlPath) {
+        this.audioUrlPath = audioUrlPath;
+    }
+
+    @Override
+    public InputStream getAudioStream() throws IOException {
+        URL url = new URL(this.audioUrlPath);
+        URLConnection connection = url.openConnection();
+        return new BufferedInputStream(connection.getInputStream());
+    }
+}


### PR DESCRIPTION
_**Important**: This PR is a draft for now as I work out some concurrency issues_

Added a `Song` entity and supporting classes to track information about a song as well as implement functionality to play/stop the song's audio. Audio is played in the background so that it won't block the main thread (i.e. the song will start playing and the subsequent code will continue to execute normally without waiting for the song to finish).

Below is an example of what creating a `Song` might look like (note that we should probably create a factory for this).
```java
AudioSource mp3Audio = new URLAudioSource("<preview_url>");  // or FileAudioSource if using local file
Song s = new Song("Closer", "The Chainsmokers", mp3Audio, new MP3SongPlayer());
```

**Note**: The implementation of `MP3SongPlayer` requires Javazoom JLayer as a dependency, which can be downloaded [here](https://web.archive.org/web/20210108055829/http://www.javazoom.net/javalayer/javalayer.html). We can think about how we manage our dependencies in a separate PR.